### PR TITLE
move relinking to common build

### DIFF
--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -71,6 +71,9 @@ RUN echo "python3-pip" >> sysdeps_run.txt && \
     cat sysdeps_run.txt | xargs ./install_debian_packages.sh && \
     rm -rf *
 
+RUN rm /usr/lib/x86_64-linux-gnu/libstdc++.so.6 && \
+    ln -s /src/r-miniconda/envs/r-reticulate/lib/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+
 # ---------------------------------------------------
 # PRODUCTION BUILD
 # ---------------------------------------------------
@@ -80,9 +83,6 @@ FROM common AS prod
 ADD R ./R
 ADD tests ./tests
 COPY DESCRIPTION NAMESPACE work.R ./
-
-RUN rm /usr/lib/x86_64-linux-gnu/libstdc++.so.6 && \
-    ln -s /src/r-miniconda/envs/r-reticulate/lib/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 
 # start app
 ENTRYPOINT ["bash", "/var/lib/watchfile/entrypoint.sh"]


### PR DESCRIPTION
# Description
PR #13 solves the issue with relinking. However, relinking was only done for the production build. This causes the build to fail in local (development).

This PR moves the relinking process out of the production build to the common build, so the changes are also reflected in local build.

https://ui-agi-worker15.scp-staging.biomage.net/

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.