### PR TITLE
set RunUMAP seed.use to 42

### DIFF
--- a/r/R/embedding.R
+++ b/r/R/embedding.R
@@ -87,7 +87,8 @@ getEmbedding <- function(config, method, reduction_type, num_pcs, data) {
       verbose = FALSE,
       min.dist = config$minimumDistance,
       metric = config$distanceMetric,
-      umap.method = "umap-learn"
+      umap.method = "umap-learn",
+      seed.use = ULTIMATE_SEED
     )
   }
 

--- a/r/tests/testthat/test-embedding.R
+++ b/r/tests/testthat/test-embedding.R
@@ -1,3 +1,5 @@
+library('mockery')
+
 mock_scdata <- function() {
   data("pbmc_small", package = "SeuratObject", envir = environment())
   pbmc_small$cells_id <- 0:(ncol(pbmc_small) - 1)
@@ -13,11 +15,56 @@ mock_scdata <- function() {
   return(pbmc_small)
 }
 
-test_that("UMAP embedding works", {
+test_that("TSNE embedding works", {
+
+  mock_RunTSNE <- function(config, method, reduction_type, num_pcs, data) {
+    Seurat::RunTSNE(data,
+     reduction = reduction_type,
+     dims = 1:num_pcs,
+     perplexity = config$perplexity,
+     learning.rate = config$learningRate,
+     check_duplicates = FALSE
+    )
+  }
+
+  reduction_method = 'tsne'
+  stub(runEmbedding, 'getEmbedding', mock_RunTSNE)
+
   data <- suppressWarnings(mock_scdata())
   req <- list(
     body = list(
-      type = "umap",
+      type = reduction_method,
+      config = list(perplexity = 10, learningRate = 100)
+    )
+  )
+
+  res <- runEmbedding(req, data)
+  expected_res <- as.data.frame(Seurat::Embeddings(data)[,1:2])
+
+  # Expect all cells to be in embedding
+  expect_equal(length(res), length(expected_res$PC_1))
+})
+
+test_that("UMAP embedding works", {
+  mock_RunUMAP <- function(config, method, reduction_type, num_pcs, data) {
+    Seurat::RunUMAP(data,
+      reduction = reduction_type,
+      dims = 1:num_pcs,
+      verbose = FALSE,
+      min.dist = config$minimumDistance,
+      metric = config$distanceMetric,
+      seed.use = ULTIMATE_SEED
+    )
+  }
+
+  stub(runEmbedding, 'getEmbedding', mock_RunUMAP)
+
+  reduction_method <- "umap"
+
+  data <- suppressWarnings(mock_scdata())
+  req <- list(
+    body = list(
+      type = reduction_method,
       config = list(minimumDistance = 0.1, distanceMetric = "cosine")
     )
   )
@@ -26,10 +73,61 @@ test_that("UMAP embedding works", {
 
   expected_res <- as.data.frame(Seurat::Embeddings(data)[,1:2])
 
-  expected_res <- expected_res %>%
-    as.data.frame() %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(PCS = list(c(PC_1, PC_2)))
+  # Expect all cells to be in embedding
+  expect_equal(length(res), length(expected_res$PC_1))
+})
 
-  expect_equal(res,expected_res$PCS)
+test_that("RunTSNE uses the correct params", {
+
+  mock_RunTSNE <- mock(TRUE)
+
+  stub(getEmbedding, 'Seurat::RunTSNE', mock_RunTSNE)
+
+  data <- suppressWarnings(mock_scdata())
+  config <- list(perplexity = 10, learningRate = 100)
+  reduction_type <- "pca"
+  method <- "tsne"
+  num_pcs <- 1
+
+  res <- getEmbedding(config, method, reduction_type, num_pcs, data)
+
+  # Check that tsne is called using the correct parameters
+  expect_equal(length(mock_RunTSNE), 1)
+  args <- mock_args(mock_RunTSNE)
+
+  expect_equal(args[[1]], list(data,
+                               reduction = reduction_type,
+                               dims = 1:num_pcs,
+                               perplexity = config$perplexity,
+                               learning.rate = config$learningRate))
+
+})
+
+test_that("RunUMAP uses umap-learn with seed.use", {
+
+  mock_RunUMAP <- mock(TRUE)
+
+  stub(getEmbedding, 'Seurat::RunUMAP', mock_RunUMAP)
+
+  data <- suppressWarnings(mock_scdata())
+  config <- list(minimumDistance = 0.1, distanceMetric = "cosine")
+  reduction_type <- "pca"
+  method <- "umap"
+  num_pcs <- 1
+
+  res <- getEmbedding(config, method, reduction_type, num_pcs, data)
+
+  # Check that umap is called using the correct parameters
+  expect_equal(length(mock_RunUMAP), 1)
+  args <- mock_args(mock_RunUMAP)
+
+  expect_equal(args[[1]], list(data,
+   reduction = reduction_type,
+   dims = 1:num_pcs,
+   verbose = FALSE,
+   min.dist = config$minimumDistance,
+   metric = config$distanceMetric,
+   umap.method = "umap-learn",
+   seed.use = ULTIMATE_SEED))
+
 })

--- a/r/tests/testthat/test-embedding.R
+++ b/r/tests/testthat/test-embedding.R
@@ -1,12 +1,3 @@
-mock_req <- function() {
-  req <- list(
-    body = list(
-      type = "umap",
-      config = list(minimumDistance = 0.1, distanceMetric = "cosine")
-    )
-  )
-}
-
 mock_scdata <- function() {
   data("pbmc_small", package = "SeuratObject", envir = environment())
   pbmc_small$cells_id <- 0:(ncol(pbmc_small) - 1)
@@ -22,10 +13,14 @@ mock_scdata <- function() {
   return(pbmc_small)
 }
 
-test_that("PCA embedding works", {
+test_that("UMAP embedding works", {
   data <- suppressWarnings(mock_scdata())
-  req <- mock_req()
-  req$body$type <- "pca"
+  req <- list(
+    body = list(
+      type = "umap",
+      config = list(minimumDistance = 0.1, distanceMetric = "cosine")
+    )
+  )
 
   res <- runEmbedding(req, data)
 


### PR DESCRIPTION
# Description
`seed.use` for RunUMAP was removed in the refactor done in #4. During the refactor, I thought that setting the seed using `set.seed` (which sets the seed for R functions) would also set seed for `umap-learn`. It turns out this is not the case.

This PR reintroduces `set.seed` back to RunUMAP.

This issue seems to also be the cause of embedding changed as reported by this user: 
https://this-is-biomage.slack.com/archives/C01A1DRDXUJ/p1662659050942829

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.