### PR TITLE
[BIOMAGE-2211] - Update repo to use FluxV2

### DIFF
--- a/.flux.yaml
+++ b/.flux.yaml
@@ -5,23 +5,31 @@ metadata:
   labels:
     sandboxId: FILLED_IN_BY_CI
 ---
-apiVersion: helm.fluxcd.io/v1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: FILLED_IN_BY_CI
+  namespace: FILLED_IN_BY_CI
+spec:
+  interval: 10m0s
+  url: https://github.com/biomage-org/worker
+  ref:
+    branch: FILLED_IN_BY_CI
+---
+apiVersion: helm.toolkit.fluxcd.io/v1beta2
 kind: HelmRelease
 metadata:
   name: FILLED_IN_BY_CI
   namespace: FILLED_IN_BY_CI
   annotations:
-    fluxcd.io/automated: "true"
     filter.fluxcd.io/r: FILLED_IN_BY_CI
     filter.fluxcd.io/python: FILLED_IN_BY_CI
   labels:
     sandboxId: FILLED_IN_BY_CI
 spec:
   releaseName: FILLED_IN_BY_CI
-  chart:
-    git: https://github.com/biomage-org/worker
-    path: chart-infra/
-    ref: FILLED_IN_BY_CI
+  intarval: 2m0s
+  chart: chart-infra/
   valuesFrom:
   - configMapKeyRef:
       name: account-config

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -63,7 +63,7 @@ spec:
   git:
     commit:
       author:
-        name: Flux CI/CD
+        name: Flux Image Autoupdate
         email: ci@biomage.net
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -63,7 +63,7 @@ spec:
   git:
     commit:
       author:
-        name: Flux Image Autoupdate
+        name: Flux - Worker image update
         email: ci@biomage.net
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -14,7 +14,7 @@ spec:
   interval: 5m0s
   url: https://github.com/biomage-org/worker
   ref:
-    branch: FILLED_IN_BY_CI
+    branch: "master"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -83,6 +83,20 @@ spec:
         kind: GitRepository
         name: FILLED_IN_BY_CI
         namespace: FILLED_IN_BY_CI
+  values:
+    sandboxId: FILLED_IN_BY_CI
+    replicaCount: FILLED_IN_BY_CI
+    r:
+      image:
+        registry: FILLED_IN_BY_CI
+        repository: FILLED_IN_BY_CI
+        tag: FILLED_IN_BY_CI
+      memoryRequest: FILLED_IN_BY_CI
+    python:
+      image:
+        registry: FILLED_IN_BY_CI
+        repository: FILLED_IN_BY_CI
+        tag: FILLED_IN_BY_CI
   valuesFrom:
     - kind: ConfigMap
       valuesKey: account-config.yaml

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -14,7 +14,7 @@ spec:
   interval: 5m0s
   url: https://github.com/biomage-org/worker
   ref:
-    branch: "master"
+    branch: FILLED_IN_BY_CI
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -11,12 +11,12 @@ metadata:
   name: FILLED_IN_BY_CI
   namespace: FILLED_IN_BY_CI
 spec:
-  interval: 10m0s
+  interval: 5m0s
   url: https://github.com/biomage-org/worker
   ref:
     branch: FILLED_IN_BY_CI
 ---
-apiVersion: helm.toolkit.fluxcd.io/v1beta2
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: FILLED_IN_BY_CI
@@ -28,10 +28,16 @@ metadata:
     sandboxId: FILLED_IN_BY_CI
 spec:
   releaseName: FILLED_IN_BY_CI
-  intarval: 2m0s
-  chart: chart-infra/
+  interval: 2m0s
+  chart:
+    spec:
+      chart: chart-infra/
+      sourceRef:
+        kind: GitRepository
+        name: FILLED_IN_BY_CI
+        namespace: FILLED_IN_BY_CI
   valuesFrom:
-  - configMapKeyRef:
+    - kind: ConfigMap
+      valuesKey: account-config.yaml
       name: account-config
-      namespace: flux
-      key: account-config.yaml
+      optional: false

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -16,14 +16,61 @@ spec:
   ref:
     branch: FILLED_IN_BY_CI
 ---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: FILLED_IN_BY_CI
+  namespace: FILLED_IN_BY_CI
+spec:
+  image: FILLED_IN_BY_CI
+  interval: 2m0s
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: FILLED_IN_BY_CI
+  namespace: FILLED_IN_BY_CI
+spec:
+  imageRepositoryRef:
+    name: FILLED_IN_BY_CI
+  filterTags:
+    pattern: FILLED_IN_BY_CI
+    extract: FILLED_IN_BY_CI
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: FILLED_IN_BY_CI
+  namespace: FILLED_IN_BY_CI
+spec:
+  imageRepositoryRef:
+    name: FILLED_IN_BY_CI
+  filterTags:
+    pattern: FILLED_IN_BY_CI
+    extract: FILLED_IN_BY_CI
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: FILLED_IN_BY_CI
+  namespace: FILLED_IN_BY_CI
+spec:
+  interval: 2m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    commit:
+      author:
+        name: Flux CI/CD
+        email: ci@biomage.net
+---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: FILLED_IN_BY_CI
   namespace: FILLED_IN_BY_CI
-  annotations:
-    filter.fluxcd.io/r: FILLED_IN_BY_CI
-    filter.fluxcd.io/python: FILLED_IN_BY_CI
   labels:
     sandboxId: FILLED_IN_BY_CI
 spec:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,17 +83,15 @@ jobs:
           # in push events, the latest commit of the master branch is GITHUB_SHA
           # in PR synch the latest commit of the branch is found in github.event.pull_request.head.sha instead
 
-          TIMESTAMP=$(date +%s)
-
           if [ "${{ github.event_name }}" = "release" ] && [ "${{ github.event.action }}" = "released" ]; then
             COMMIT_SHA=""
             IMAGE_TAG=$REF_ID
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
-            IMAGE_TAG="$REF_ID-$COMMIT_SHA-$TIMESTAMP"
+            IMAGE_TAG="$REF_ID-$COMMIT_SHA"
           else
             COMMIT_SHA=$GITHUB_SHA
-            IMAGE_TAG="$REF_ID-$COMMIT_SHA-$TIMESTAMP"
+            IMAGE_TAG="$REF_ID-$COMMIT_SHA"
           fi
 
           # IMAGE_TAG is used in the Build Docker Image step.
@@ -256,8 +254,10 @@ jobs:
           docker tag $IMAGE_NAME-python-ci $IMAGE_NAME-python
           docker tag $IMAGE_NAME-r-ci $IMAGE_NAME-r
 
-          docker push $IMAGE_NAME-python
-          docker push $IMAGE_NAME-r
+          TIMESTAMP=$(date +%s)
+
+          docker push $IMAGE_NAME-$TIMESTAMP-python
+          docker push $IMAGE_NAME-$TIMESTAMP-r
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.image-tag) }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -324,7 +324,7 @@ jobs:
           echo "::set-output name=sandbox-id::$SANDBOX_ID"
           echo "::set-output name=kubernetes-env::$KUBERNETES_ENV"
 
-          NAMESPACE="$DEPLOYMENT_NAME-$SANDBOX_ID"
+          export NAMESPACE="$DEPLOYMENT_NAME-$SANDBOX_ID"
 
           yq '
             select(di == 0).metadata.name = strenv(NAMESPACE) |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -375,10 +375,10 @@ jobs:
             select(di == 6).spec.values.sandboxId = strenv(SANDBOX_ID) |
             select(di == 6).spec.values.replicaCount = env(REPLICA_COUNT) |
             select(di == 6).spec.values.r.image = strenv(IMAGE_NAME) + "-r" |
-            select(di == 6).spec.values.r.image = line_comment = strenv(R_IMAGE_POLICY_TAG) |
+            select(di == 6).spec.values.r.image line_comment = strenv(R_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
             select(di == 6).spec.values.python.image = strenv(IMAGE_NAME) + "-python" |
-            select(di == 6).spec.values.r.image = line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
+            select(di == 6).spec.values.python.image line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE)
           ' .flux.yaml > $DEPLOYMENT_NAME.yaml
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,7 +326,7 @@ jobs:
             export CHART_REF="FILLED_IN_BY_BIOMAGE_STAGE"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
-            export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)$"
+            export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)"
             export IMAGE_EXTRACT='$timestamp'
             export IMAGE_POLICY_TYPE="numerical"
             export IMAGE_POLICY_KEY="order"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -317,7 +317,7 @@ jobs:
             export SANDBOX_ID="default"
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="production"
-            export IMAGE_TAG="$IMAGE_NAME"
+            export IMAGE_NAME="$IMAGE_TAG"
             export REPLICA_COUNT="2"
             export IMAGE_PATTERN="^refs-tags-(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
             export IMAGE_EXTRACT='$version'
@@ -332,7 +332,7 @@ jobs:
             export SANDBOX_ID="default"
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="staging"
-            export IMAGE_TAG="$IMAGE_NAME-$TIMESTAMP"
+            export IMAGE_NAME="$IMAGE_TAG-$TIMESTAMP"
             export REPLICA_COUNT="0"
             export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)"
             export IMAGE_EXTRACT='$timestamp'
@@ -347,7 +347,7 @@ jobs:
             export SANDBOX_ID="STAGING_SANDBOX_ID"
             export CHART_REF="FILLED_IN_BY_BIOMAGE_STAGE"
             export KUBERNETES_ENV="staging"
-            export IMAGE_TAG="$IMAGE_NAME-$TIMESTAMP"
+            export IMAGE_NAME="$IMAGE_TAG-$TIMESTAMP"
             export REPLICA_COUNT="0"
             export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)"
             export IMAGE_EXTRACT='$timestamp'
@@ -398,22 +398,23 @@ jobs:
             select(di == 6).spec.values.sandboxId = strenv(SANDBOX_ID) |
             select(di == 6).spec.values.replicaCount = env(REPLICA_COUNT) |
             select(di == 6).spec.values.r.image.registry = strenv(REGISTRY) |
-            select(di == 6).spec.values.r.image.repository = strenv(GITHUB_REPOSITORY) |
-            select(di == 6).spec.values.r.image.tag = strenv(IMAGE_TAG) + "-r" |
+            select(di == 6).spec.values.r.image.repository = strenv(REPOSITORY) |
+            select(di == 6).spec.values.r.image.tag = strenv(IMAGE_NAME) + "-r" |
             select(di == 6).spec.values.r.image.tag line_comment = strenv(R_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
             select(di == 6).spec.values.python.image.registry = strenv(REGISTRY) |
-            select(di == 6).spec.values.python.image.repository = strenv(GITHUB_REPOSITORY) |
-            select(di == 6).spec.values.python.image.tag = strenv(IMAGE_TAG) + "-python" |
+            select(di == 6).spec.values.python.image.repository = strenv(REPOSITORY) |
+            select(di == 6).spec.values.python.image.tag = strenv(IMAGE_NAME) + "-python" |
             select(di == 6).spec.values.python.image.tag line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE)
           ' .flux.yaml > $DEPLOYMENT_NAME.yaml
 
           cat $DEPLOYMENT_NAME.yaml
         env:
-          IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.image-tag) }}
+          IMAGE_TAG: ${{ needs.build-docker.outputs.image-tag) }}
           REF_ID: ${{ needs.build-docker.outputs.ref-id }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ needs.build-docker.outputs.repo-name }}
           TIMESTAMP: ${{ needs.build-docker.outputs.timestamp }}
 
       - name: Push production/develop template to releases

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,15 +83,17 @@ jobs:
           # in push events, the latest commit of the master branch is GITHUB_SHA
           # in PR synch the latest commit of the branch is found in github.event.pull_request.head.sha instead
 
+          TIMESTAMP=$(date +%s)
+
           if [ "${{ github.event_name }}" = "release" ] && [ "${{ github.event.action }}" = "released" ]; then
             COMMIT_SHA=""
             IMAGE_TAG=$REF_ID
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
-            IMAGE_TAG="$REF_ID-$COMMIT_SHA"
+            IMAGE_TAG="$REF_ID-$COMMIT_SHA-$TIMESTAMP"
           else
             COMMIT_SHA=$GITHUB_SHA
-            IMAGE_TAG="$REF_ID-$COMMIT_SHA"
+            IMAGE_TAG="$REF_ID-$COMMIT_SHA-$TIMESTAMP"
           fi
 
           # IMAGE_TAG is used in the Build Docker Image step.
@@ -296,8 +298,11 @@ jobs:
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="production"
             export REPLICA_COUNT="2"
-            export VERSION_NUMBER=${REF_ID/refs-tags-/}
-            export IMAGE_GLOB="${REF_ID/$VERSION_NUMBER/*}"
+            export IMAGE_PATTERN="^refs-tags-(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
+            export IMAGE_EXTRACT='$version'
+            export IMAGE_POLICY_TYPE="semver"
+            export IMAGE_POLICY_KEY="range"
+            export IMAGE_POLICY_VALUE=">=0.0.0"
             export MEMORY_REQUEST="28Gi"
           fi
 
@@ -307,7 +312,11 @@ jobs:
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
-            export IMAGE_GLOB="$REF_ID-*"
+            export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)$"
+            export IMAGE_EXTRACT='$timestamp'
+            export IMAGE_POLICY_TYPE="numerical"
+            export IMAGE_POLICY_KEY="order"
+            export IMAGE_POLICY_VALUE="asc"
             export MEMORY_REQUEST="28Gi"
           fi
 
@@ -317,7 +326,11 @@ jobs:
             export CHART_REF="FILLED_IN_BY_BIOMAGE_STAGE"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
-            export IMAGE_GLOB="$REF_ID-*"
+            export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)$"
+            export IMAGE_EXTRACT='$timestamp'
+            export IMAGE_POLICY_TYPE="numerical"
+            export IMAGE_POLICY_KEY="order"
+            export IMAGE_POLICY_VALUE="asc"
             export MEMORY_REQUEST="4Gi"
           fi
 
@@ -325,6 +338,8 @@ jobs:
           echo "::set-output name=kubernetes-env::$KUBERNETES_ENV"
 
           export NAMESPACE="$DEPLOYMENT_NAME-$SANDBOX_ID"
+          export R_IMAGE_POLICY_TAG="{\"\$imagepolicy\": \"$NAMESPACE:$DEPLOYMENT_NAME-r:tag\"}"
+          export PYTHON_IMAGE_POLICY_TAG="{\"\$imagepolicy\": \"$NAMESPACE:$DEPLOYMENT_NAME-python:tag\"}"
 
           yq '
             select(di == 0).metadata.name = strenv(NAMESPACE) |
@@ -334,20 +349,37 @@ jobs:
             select(di == 1).spec.ref.branch = strenv(CHART_REF) |
             select(di == 2).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 2).metadata.namespace = strenv(NAMESPACE) |
-            select(di == 2).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
-            select(di == 2).spec.releaseName = strenv(DEPLOYMENT_NAME) |
-            select(di == 2).spec.chart.spec.sourceRef.name = strenv(DEPLOYMENT_NAME) |
-            select(di == 2).spec.chart.spec.sourceRef.namespace = strenv(NAMESPACE) |
-            select(di == 2).spec.values.kubernetes.env = strenv(KUBERNETES_ENV) |
-            select(di == 2).spec.values.serviceAccount.iamRole = "worker-role-" + strenv(KUBERNETES_ENV) |
-            select(di == 2).spec.values.sandboxId = strenv(SANDBOX_ID) |
-            select(di == 2).spec.values.replicaCount = env(REPLICA_COUNT) |
-            select(di == 2).spec.values.r.image = strenv(IMAGE_NAME) + "-r" |
-            select(di == 2).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
-            select(di == 2).spec.values.python.image = strenv(IMAGE_NAME) + "-python" |
-            select(di == 2).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE) |
-            select(di == 2).metadata.annotations["filter.fluxcd.io/r"] = "glob:" + strenv(IMAGE_GLOB) + "-r" |
-            select(di == 2).metadata.annotations["filter.fluxcd.io/python"] = "glob:" + strenv(IMAGE_GLOB) + "-python"
+            select(di == 2).spec.image = strenv(REGISTRY) + "/" + strenv(DEPLOYMENT_NAME) |
+            select(di == 3).metadata.name = strenv(DEPLOYMENT_NAME) + "-r" |
+            select(di == 3).metadata.namespace = strenv(NAMESPACE) |
+            select(di == 3).spec.imageRepositoryRef.name = strenv(DEPLOYMENT_NAME) |
+            select(di == 3).spec.filterTags.pattern = strenv(IMAGE_PATTERN) + "-r" |
+            select(di == 3).spec.filterTags.extract = strenv(IMAGE_EXTRACT) |
+            select(di == 3).spec.policy.[strenv(IMAGE_POLICY_TYPE)].[strenv(IMAGE_POLICY_KEY)] = strenv(IMAGE_POLICY_VALUE) |
+            select(di == 4).metadata.name = strenv(DEPLOYMENT_NAME) + "-python" |
+            select(di == 4).metadata.namespace = strenv(NAMESPACE) |
+            select(di == 4).spec.imageRepositoryRef.name = strenv(DEPLOYMENT_NAME) |
+            select(di == 4).spec.filterTags.pattern = strenv(IMAGE_PATTERN) + "-python" |
+            select(di == 4).spec.filterTags.extract = strenv(IMAGE_EXTRACT) |
+            select(di == 4).spec.policy.[strenv(IMAGE_POLICY_TYPE)].[strenv(IMAGE_POLICY_KEY)] = strenv(IMAGE_POLICY_VALUE) |
+            select(di == 5).metadata.name = strenv(DEPLOYMENT_NAME) + "-image-update" |
+            select(di == 5).metadata.namespace = strenv(NAMESPACE) |
+            select(di == 6).metadata.name = strenv(DEPLOYMENT_NAME) |
+            select(di == 6).metadata.namespace = strenv(NAMESPACE) |
+            select(di == 6).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
+            select(di == 6).spec.releaseName = strenv(DEPLOYMENT_NAME) |
+            select(di == 6).spec.chart.spec.sourceRef.name = strenv(DEPLOYMENT_NAME) |
+            select(di == 6).spec.chart.spec.sourceRef.namespace = strenv(NAMESPACE) |
+            select(di == 6).spec.values.kubernetes.env = strenv(KUBERNETES_ENV) |
+            select(di == 6).spec.values.serviceAccount.iamRole = "worker-role-" + strenv(KUBERNETES_ENV) |
+            select(di == 6).spec.values.sandboxId = strenv(SANDBOX_ID) |
+            select(di == 6).spec.values.replicaCount = env(REPLICA_COUNT) |
+            select(di == 6).spec.values.r.image = strenv(IMAGE_NAME) + "-r" |
+            select(di == 6).spec.values.r.image = line_comment = strenv(R_IMAGE_POLICY_TAG) |
+            select(di == 6).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
+            select(di == 6).spec.values.python.image = strenv(IMAGE_NAME) + "-python" |
+            select(di == 6).spec.values.r.image = line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
+            select(di == 6).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE)
           ' .flux.yaml > $DEPLOYMENT_NAME.yaml
 
           cat $DEPLOYMENT_NAME.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,7 +299,6 @@ jobs:
           if [ "${{ matrix.environment }}" = "production" ]; then
             SANDBOX_ID="default"
             CHART_REF="$GITHUB_SHA"
-            REF_TYPE="branch"
             KUBERNETES_ENV="production"
             REPLICA_COUNT="2"
             VERSION_NUMBER=${REF_ID/refs-tags-/}
@@ -311,7 +310,6 @@ jobs:
           if [ "${{ matrix.environment }}" = "develop" ]; then
             SANDBOX_ID="default"
             CHART_REF="$GITHUB_SHA"
-            REF_TYPE="branch"
             KUBERNETES_ENV="staging"
             REPLICA_COUNT="0"
             IMAGE_GLOB="$REF_ID-*"
@@ -322,7 +320,6 @@ jobs:
           if [ "${{ matrix.environment }}" = "staging" ]; then
             SANDBOX_ID="STAGING_SANDBOX_ID"
             CHART_REF="STAGING_CHART_REF"
-            REF_TYPE="commit"
             KUBERNETES_ENV="staging"
             REPLICA_COUNT="0"
             IMAGE_GLOB="$REF_ID-*"
@@ -332,15 +329,19 @@ jobs:
           echo "::set-output name=sandbox-id::$SANDBOX_ID"
           echo "::set-output name=kubernetes-env::$KUBERNETES_ENV"
 
-          yq w -d0 .flux.yaml metadata.name "$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          NAMESPACE="$DEPLOYMENT_NAME-$SANDBOX_ID"
+
+          yq w -d0 .flux.yaml metadata.name "$NAMESPACE" \
           | yq w -d0 - metadata.labels.sandboxId "$SANDBOX_ID" \
           | yq w -d1 - metadata.name "$DEPLOYMENT_NAME" \
-          | yq w -d1 - metadata.namespace "$DEPLOYMENT_NAME-$SANDBOX_ID" \
-          | yq w -d1 - spec.ref."$REF_TYPE" "$CHART_REF" \
+          | yq w -d1 - metadata.namespace "$NAMESPACE" \
+          | yq w -d1 - spec.ref.branch "$CHART_REF" \
           | yq w -d2 - metadata.name "$DEPLOYMENT_NAME" \
-          | yq w -d2 - metadata.namespace "$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          | yq w -d2 - metadata.namespace "$NAMESPACE" \
           | yq w -d2 - metadata.labels.sandboxId "$SANDBOX_ID" \
           | yq w -d2 - spec.releaseName "$DEPLOYMENT_NAME" \
+          | yq w -d2 - spec.chart.spec.chart.sourceRef.name "$DEPLOYMENT_NAME" \
+          | yq w -d2 - spec.chart.spec.chart.sourceRef.namespace "$NAMESPACE" \
           | yq w -d2 - spec.values.kubernetes.env "$KUBERNETES_ENV" \
           | yq w -d2 - spec.values.serviceAccount.iamRole "worker-role-$KUBERNETES_ENV" \
           | yq w -d2 - spec.values.sandboxId "$SANDBOX_ID" \
@@ -348,7 +349,7 @@ jobs:
           | yq w -d2 - spec.values.r.image "$IMAGE_NAME-r" \
           | yq w -d2 - spec.values.r.memoryRequest "$MEMORY_REQUEST" \
           | yq w -d2 - spec.values.python.image "$IMAGE_NAME-python" \
-          | yq w -d2 - spec.values.datadogTags "kube_namespace:$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          | yq w -d2 - spec.values.datadogTags "kube_namespace:$NAMESPACE" \
           | yq w -d2 - "metadata.annotations[filter.fluxcd.io/r]" "glob:$IMAGE_GLOB-r" \
           | yq w -d2 - "metadata.annotations[filter.fluxcd.io/python]" "glob:$IMAGE_GLOB-python" \
           > $DEPLOYMENT_NAME.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -328,6 +328,7 @@ jobs:
             select(di == 0).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
             select(di == 1).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 1).metadata.namespace = strenv(NAMESPACE) |
+            select(di == 1).spec.ref.branch = strenv(REF_ID) |
             select(di == 2).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 2).metadata.namespace = strenv(NAMESPACE) |
             select(di == 2).metadata.labels.sandboxId = strenv(SANDBOX_ID) |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,7 +279,7 @@ jobs:
           fi
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.image-tag) }}
-          TIMESTAMP: ${{ steps.ref.output.timestamp }}
+          TIMESTAMP: ${{ needs.build-docker.outputs.timestamp }}
 
   deploy:
     name: Deploy to Kubernetes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,7 +312,7 @@ jobs:
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
-            export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)$"
+            export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)"
             export IMAGE_EXTRACT='$timestamp'
             export IMAGE_POLICY_TYPE="numerical"
             export IMAGE_POLICY_KEY="order"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -405,7 +405,7 @@ jobs:
             select(di == 6).spec.values.python.image.registry = strenv(REGISTRY) |
             select(di == 6).spec.values.python.image.repository = strenv(GITHUB_REPOSITORY) |
             select(di == 6).spec.values.python.image.tag = strenv(IMAGE_TAG) + "-python" |
-            select(di == 6).spec.values.python.image line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
+            select(di == 6).spec.values.python.image.tag line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE)
           ' .flux.yaml > $DEPLOYMENT_NAME.yaml
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,10 +251,10 @@ jobs:
         name: Push docker images to ECR
         run: |-
           echo Pushing image $IMAGE_NAME-[python/r] to ECR.
-          docker tag $IMAGE_NAME-python-ci $IMAGE_NAME-python
-          docker tag $IMAGE_NAME-r-ci $IMAGE_NAME-r
-
           TIMESTAMP=$(date +%s)
+
+          docker tag $IMAGE_NAME-python-ci $IMAGE_NAME-$TIMESTAMP-python
+          docker tag $IMAGE_NAME-r-ci $IMAGE_NAME-$TIMESTAMP-r
 
           docker push $IMAGE_NAME-$TIMESTAMP-python
           docker push $IMAGE_NAME-$TIMESTAMP-r

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -411,7 +411,7 @@ jobs:
 
           cat $DEPLOYMENT_NAME.yaml
         env:
-          IMAGE_TAG: ${{ needs.build-docker.outputs.image-tag) }}
+          IMAGE_TAG: ${{ needs.build-docker.outputs.image-tag }}
           REF_ID: ${{ needs.build-docker.outputs.ref-id }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ needs.build-docker.outputs.repo-name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -340,8 +340,8 @@ jobs:
           | yq w -d2 - metadata.namespace "$NAMESPACE" \
           | yq w -d2 - metadata.labels.sandboxId "$SANDBOX_ID" \
           | yq w -d2 - spec.releaseName "$DEPLOYMENT_NAME" \
-          | yq w -d2 - spec.chart.spec.chart.sourceRef.name "$DEPLOYMENT_NAME" \
-          | yq w -d2 - spec.chart.spec.chart.sourceRef.namespace "$NAMESPACE" \
+          | yq w -d2 - spec.chart.spec.sourceRef.name "$DEPLOYMENT_NAME" \
+          | yq w -d2 - spec.chart.spec.sourceRef.namespace "$NAMESPACE" \
           | yq w -d2 - spec.values.kubernetes.env "$KUBERNETES_ENV" \
           | yq w -d2 - spec.values.serviceAccount.iamRole "worker-role-$KUBERNETES_ENV" \
           | yq w -d2 - spec.values.sandboxId "$SANDBOX_ID" \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,6 @@ jobs:
           # Deployment config for `production-default`
           if [ "${{ matrix.environment }}" = "production" ]; then
             export SANDBOX_ID="default"
-            export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="production"
             export REPLICA_COUNT="2"
             export VERSION_NUMBER=${REF_ID/refs-tags-/}
@@ -304,7 +303,6 @@ jobs:
           # Deployment config for `staging-default`
           if [ "${{ matrix.environment }}" = "develop" ]; then
             export SANDBOX_ID="default"
-            export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
             export IMAGE_GLOB="$REF_ID-*"
@@ -314,7 +312,6 @@ jobs:
           # Deployment config for other staging env i.e. non `default`
           if [ "${{ matrix.environment }}" = "staging" ]; then
             export SANDBOX_ID="STAGING_SANDBOX_ID"
-            export CHART_REF="STAGING_CHART_REF"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
             export IMAGE_GLOB="$REF_ID-*"
@@ -331,7 +328,6 @@ jobs:
             select(di == 0).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
             select(di == 1).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 1).metadata.namespace = strenv(NAMESPACE) |
-            select(di == 1).spec.ref.branch = strenv(CHART_REF) |
             select(di == 2).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 2).metadata.namespace = strenv(NAMESPACE) |
             select(di == 2).metadata.labels.sandboxId = strenv(SANDBOX_ID) |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,7 +345,7 @@ jobs:
           # Deployment config for other staging env i.e. non `default`
           if [ "${{ matrix.environment }}" = "staging" ]; then
             export SANDBOX_ID="STAGING_SANDBOX_ID"
-            export CHART_REF="FILLED_IN_BY_BIOMAGE_STAGE"
+            export CHART_REF="$GITHUB_HEAD_REF"
             export KUBERNETES_ENV="staging"
             export IMAGE_NAME="$IMAGE_TAG-$TIMESTAMP"
             export REPLICA_COUNT="0"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,6 +299,7 @@ jobs:
           if [ "${{ matrix.environment }}" = "production" ]; then
             SANDBOX_ID="default"
             CHART_REF="$GITHUB_SHA"
+            REF_TYPE="branch"
             KUBERNETES_ENV="production"
             REPLICA_COUNT="2"
             VERSION_NUMBER=${REF_ID/refs-tags-/}
@@ -310,6 +311,7 @@ jobs:
           if [ "${{ matrix.environment }}" = "develop" ]; then
             SANDBOX_ID="default"
             CHART_REF="$GITHUB_SHA"
+            REF_TYPE="branch"
             KUBERNETES_ENV="staging"
             REPLICA_COUNT="0"
             IMAGE_GLOB="$REF_ID-*"
@@ -320,6 +322,7 @@ jobs:
           if [ "${{ matrix.environment }}" = "staging" ]; then
             SANDBOX_ID="STAGING_SANDBOX_ID"
             CHART_REF="STAGING_CHART_REF"
+            REF_TYPE="commit"
             KUBERNETES_ENV="staging"
             REPLICA_COUNT="0"
             IMAGE_GLOB="$REF_ID-*"
@@ -329,23 +332,25 @@ jobs:
           echo "::set-output name=sandbox-id::$SANDBOX_ID"
           echo "::set-output name=kubernetes-env::$KUBERNETES_ENV"
 
-          yq w -d1 .flux.yaml metadata.name "$DEPLOYMENT_NAME" \
-          | yq w -d1 - metadata.namespace "$DEPLOYMENT_NAME-$SANDBOX_ID" \
-          | yq w -d0 - metadata.name "$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          yq w -d0 .flux.yaml metadata.name "$DEPLOYMENT_NAME-$SANDBOX_ID" \
           | yq w -d0 - metadata.labels.sandboxId "$SANDBOX_ID" \
-          | yq w -d1 - metadata.labels.sandboxId "$SANDBOX_ID" \
-          | yq w -d1 - spec.releaseName "$DEPLOYMENT_NAME" \
-          | yq w -d1 - spec.chart.ref "$CHART_REF" \
-          | yq w -d1 - spec.values.kubernetes.env "$KUBERNETES_ENV" \
-          | yq w -d1 - spec.values.serviceAccount.iamRole "worker-role-$KUBERNETES_ENV" \
-          | yq w -d1 - spec.values.sandboxId "$SANDBOX_ID" \
-          | yq w -d1 - spec.values.replicaCount $REPLICA_COUNT \
-          | yq w -d1 - spec.values.r.image "$IMAGE_NAME-r" \
-          | yq w -d1 - spec.values.r.memoryRequest "$MEMORY_REQUEST" \
-          | yq w -d1 - spec.values.python.image "$IMAGE_NAME-python" \
-          | yq w -d1 - spec.values.datadogTags "kube_namespace:$DEPLOYMENT_NAME-$SANDBOX_ID" \
-          | yq w -d1 - "metadata.annotations[filter.fluxcd.io/r]" "glob:$IMAGE_GLOB-r" \
-          | yq w -d1 - "metadata.annotations[filter.fluxcd.io/python]" "glob:$IMAGE_GLOB-python" \
+          | yq w -d1 - metadata.name "$DEPLOYMENT_NAME" \
+          | yq w -d1 - metadata.namespace "$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          | yq w -d1 - spec.ref."$REF_TYPE" "$CHART_REF" \
+          | yq w -d2 - metadata.name "$DEPLOYMENT_NAME" \
+          | yq w -d2 - metadata.namespace "$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          | yq w -d2 - metadata.labels.sandboxId "$SANDBOX_ID" \
+          | yq w -d2 - spec.releaseName "$DEPLOYMENT_NAME" \
+          | yq w -d2 - spec.values.kubernetes.env "$KUBERNETES_ENV" \
+          | yq w -d2 - spec.values.serviceAccount.iamRole "worker-role-$KUBERNETES_ENV" \
+          | yq w -d2 - spec.values.sandboxId "$SANDBOX_ID" \
+          | yq w -d2 - spec.values.replicaCount $REPLICA_COUNT \
+          | yq w -d2 - spec.values.r.image "$IMAGE_NAME-r" \
+          | yq w -d2 - spec.values.r.memoryRequest "$MEMORY_REQUEST" \
+          | yq w -d2 - spec.values.python.image "$IMAGE_NAME-python" \
+          | yq w -d2 - spec.values.datadogTags "kube_namespace:$DEPLOYMENT_NAME-$SANDBOX_ID" \
+          | yq w -d2 - "metadata.annotations[filter.fluxcd.io/r]" "glob:$IMAGE_GLOB-r" \
+          | yq w -d2 - "metadata.annotations[filter.fluxcd.io/python]" "glob:$IMAGE_GLOB-python" \
           > $DEPLOYMENT_NAME.yaml
 
           cat $DEPLOYMENT_NAME.yaml
@@ -383,7 +388,7 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
           source_file: ${{ needs.build-docker.outputs.ref-id }}.yaml
-          destination_repo: '${{ github.repository_owner }}/releases'
+          destination_repo: '${{ github.repository_owner }}/flux-v2-migration'
           destination_folder: 'staging-candidates/${{ steps.fill-metadata.outputs.deployment-name }}'
           user_email: 'ci@biomage.net'
           user_name: 'Biomage CI/CD'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,6 +293,7 @@ jobs:
           # Deployment config for `production-default`
           if [ "${{ matrix.environment }}" = "production" ]; then
             export SANDBOX_ID="default"
+            export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="production"
             export REPLICA_COUNT="2"
             export VERSION_NUMBER=${REF_ID/refs-tags-/}
@@ -303,6 +304,7 @@ jobs:
           # Deployment config for `staging-default`
           if [ "${{ matrix.environment }}" = "develop" ]; then
             export SANDBOX_ID="default"
+            export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
             export IMAGE_GLOB="$REF_ID-*"
@@ -312,6 +314,7 @@ jobs:
           # Deployment config for other staging env i.e. non `default`
           if [ "${{ matrix.environment }}" = "staging" ]; then
             export SANDBOX_ID="STAGING_SANDBOX_ID"
+            export CHART_REF="FILLED_IN_BY_BIOMAGE_STAGE"
             export KUBERNETES_ENV="staging"
             export REPLICA_COUNT="0"
             export IMAGE_GLOB="$REF_ID-*"
@@ -328,7 +331,7 @@ jobs:
             select(di == 0).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
             select(di == 1).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 1).metadata.namespace = strenv(NAMESPACE) |
-            select(di == 1).spec.ref.branch = strenv(REF_ID) |
+            select(di == 1).spec.ref.branch = strenv(CHART_REF) |
             select(di == 2).metadata.name = strenv(DEPLOYMENT_NAME) |
             select(di == 2).metadata.namespace = strenv(NAMESPACE) |
             select(di == 2).metadata.labels.sandboxId = strenv(SANDBOX_ID) |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,7 +363,7 @@ jobs:
 
           export NAMESPACE="$DEPLOYMENT_NAME-$SANDBOX_ID"
           export R_IMAGE_POLICY_TAG="{\"\$imagepolicy\": \"$NAMESPACE:$DEPLOYMENT_NAME-r:tag\"}"
-          export CHART_CRD_NAME="$DEPLOYENT_NAME-chart"
+          export CHART_CRD_NAME="$DEPLOYMENT_NAME-chart"
           export PYTHON_IMAGE_POLICY_TAG="{\"\$imagepolicy\": \"$NAMESPACE:$DEPLOYMENT_NAME-python:tag\"}"
 
           yq '

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -386,6 +386,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.image-tag) }}
           REF_ID: ${{ needs.build-docker.outputs.ref-id }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
 
       - name: Push production/develop template to releases
         if:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,8 @@ jobs:
           echo "::set-output name=image-tag::$IMAGE_TAG"
 
           # TIMESTAMP is used to postfix images in the "push docker images to ECR" step.
-          # We want to add timestamp tags for PR and staging images.
+          # The timestamp is used by Flux to auto update images for staging environments.
+          # Images for production uses semantic versioning to determine the latest image.
           echo "::set-output name=timestamp::$TIMESTAMP"
 
           # This will take a GitHub repo name like `biomage-org/iac`

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
       repo-name: ${{ steps.ref.outputs.repo-name }}
       image-tag: ${{ steps.ref.outputs.image-tag }}
       ref-id: ${{ steps.ref.outputs.ref-id }}
+      timestamp: ${{ steps.ref.outputs.timestamp }}
     defaults:
       run:
         working-directory: ${{ matrix.project }}
@@ -83,21 +84,30 @@ jobs:
           # in push events, the latest commit of the master branch is GITHUB_SHA
           # in PR synch the latest commit of the branch is found in github.event.pull_request.head.sha instead
 
+          TIMESTAMP=$(date +%s)
+
           if [ "${{ github.event_name }}" = "release" ] && [ "${{ github.event.action }}" = "released" ]; then
             COMMIT_SHA=""
             IMAGE_TAG=$REF_ID
+            TIMESTAMP=""
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
             IMAGE_TAG="$REF_ID-$COMMIT_SHA"
+            TIMESTAMP=$TIMESTAMP
           else
             COMMIT_SHA=$GITHUB_SHA
             IMAGE_TAG="$REF_ID-$COMMIT_SHA"
+            TIMESTAMP=$TIMESTAMP
           fi
 
           # IMAGE_TAG is used in the Build Docker Image step.
           # We can easily build the image-tag from REF_ID and COMMIT_SHA for non-production releases.
           # But we can not easily create the image tag for production releases, so we're bulding it here
           echo "::set-output name=image-tag::$IMAGE_TAG"
+
+          # TIMESTAMP is used to postfix images in the "push docker images to ECR" step.
+          # We want to add timestamp tags for PR and staging images.
+          echo "::set-output name=timestamp::$TIMESTAMP"
 
           # This will take a GitHub repo name like `biomage-org/iac`
           # and turns it into `iac`. This will be the name of the
@@ -186,7 +196,7 @@ jobs:
           echo Pushing image $IMAGE_NAME-builder to ECR.
           docker push $IMAGE_NAME-builder
 
-          echo Pushing image $IMAGE_NAME-builder-ci to ECR.
+          echo Pushing image $IMAGE_NAME-ci to ECR.
           docker push $IMAGE_NAME-ci
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}-{3}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref.outputs.image-tag, matrix.project) }}
@@ -251,15 +261,25 @@ jobs:
         name: Push docker images to ECR
         run: |-
           echo Pushing image $IMAGE_NAME-[python/r] to ECR.
-          TIMESTAMP=$(date +%s)
 
-          docker tag $IMAGE_NAME-python-ci $IMAGE_NAME-$TIMESTAMP-python
-          docker tag $IMAGE_NAME-r-ci $IMAGE_NAME-$TIMESTAMP-r
+          docker tag $IMAGE_NAME-python-ci $IMAGE_NAME-python
+          docker tag $IMAGE_NAME-r-ci $IMAGE_NAME-r
 
-          docker push $IMAGE_NAME-$TIMESTAMP-python
-          docker push $IMAGE_NAME-$TIMESTAMP-r
+          docker push $IMAGE_NAME-python
+          docker push $IMAGE_NAME-r
+
+          if[ ! -z "$TIMESTAMP" ]; then
+            echo Pushing timestamped $IMAGE_NAME-[python/r] to ECR
+
+            docker tag $IMAGE_NAME-python $IMAGE_NAME-$TIMESTAMP-python
+            docker tag $IMAGE_NAME-r $IMAGE_NAME-$TIMESTAMP-r
+
+            docker push $IMAGE_NAME-$TIMESTAMP-python
+            docker push $IMAGE_NAME-$TIMESTAMP-r
+          fi
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.image-tag) }}
+          TIMESTAMP: ${{ steps.ref.output.timestamp }}
 
   deploy:
     name: Deploy to Kubernetes
@@ -297,6 +317,7 @@ jobs:
             export SANDBOX_ID="default"
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="production"
+            export IMAGE_TAG="$IMAGE_NAME"
             export REPLICA_COUNT="2"
             export IMAGE_PATTERN="^refs-tags-(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
             export IMAGE_EXTRACT='$version'
@@ -311,6 +332,7 @@ jobs:
             export SANDBOX_ID="default"
             export CHART_REF="$GITHUB_SHA"
             export KUBERNETES_ENV="staging"
+            export IMAGE_TAG="$IMAGE_NAME-$TIMESTAMP"
             export REPLICA_COUNT="0"
             export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)"
             export IMAGE_EXTRACT='$timestamp'
@@ -325,6 +347,7 @@ jobs:
             export SANDBOX_ID="STAGING_SANDBOX_ID"
             export CHART_REF="FILLED_IN_BY_BIOMAGE_STAGE"
             export KUBERNETES_ENV="staging"
+            export IMAGE_TAG="$IMAGE_NAME-$TIMESTAMP"
             export REPLICA_COUNT="0"
             export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)"
             export IMAGE_EXTRACT='$timestamp'
@@ -374,10 +397,10 @@ jobs:
             select(di == 6).spec.values.serviceAccount.iamRole = "worker-role-" + strenv(KUBERNETES_ENV) |
             select(di == 6).spec.values.sandboxId = strenv(SANDBOX_ID) |
             select(di == 6).spec.values.replicaCount = env(REPLICA_COUNT) |
-            select(di == 6).spec.values.r.image = strenv(IMAGE_NAME) + "-r" |
+            select(di == 6).spec.values.r.image = strenv(IMAGE_TAG) + "-r" |
             select(di == 6).spec.values.r.image line_comment = strenv(R_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
-            select(di == 6).spec.values.python.image = strenv(IMAGE_NAME) + "-python" |
+            select(di == 6).spec.values.python.image = strenv(IMAGE_TAG) + "-python" |
             select(di == 6).spec.values.python.image line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE)
           ' .flux.yaml > $DEPLOYMENT_NAME.yaml
@@ -387,6 +410,7 @@ jobs:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, needs.build-docker.outputs.repo-name, needs.build-docker.outputs.image-tag) }}
           REF_ID: ${{ needs.build-docker.outputs.ref-id }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          TIMESTAMP: ${{ needs.build-docker.outputs.timestamp }}
 
       - name: Push production/develop template to releases
         if:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -399,7 +399,7 @@ jobs:
             select(di == 6).spec.values.replicaCount = env(REPLICA_COUNT) |
             select(di == 6).spec.values.r.image.registry = strenv(REGISTRY) |
             select(di == 6).spec.values.r.image.repository = strenv(GITHUB_REPOSITORY) |
-            select(di == 6).spec.values.r.image,tag = strenv(IMAGE_TAG) + "-r" |
+            select(di == 6).spec.values.r.image.tag = strenv(IMAGE_TAG) + "-r" |
             select(di == 6).spec.values.r.image.tag line_comment = strenv(R_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
             select(di == 6).spec.values.python.image.registry = strenv(REGISTRY) |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,7 +268,7 @@ jobs:
           docker push $IMAGE_NAME-python
           docker push $IMAGE_NAME-r
 
-          if[ ! -z "$TIMESTAMP" ]; then
+          if [ ! -z "$TIMESTAMP" ]; then
             echo Pushing timestamped $IMAGE_NAME-[python/r] to ECR
 
             docker tag $IMAGE_NAME-python $IMAGE_NAME-$TIMESTAMP-python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -397,10 +397,14 @@ jobs:
             select(di == 6).spec.values.serviceAccount.iamRole = "worker-role-" + strenv(KUBERNETES_ENV) |
             select(di == 6).spec.values.sandboxId = strenv(SANDBOX_ID) |
             select(di == 6).spec.values.replicaCount = env(REPLICA_COUNT) |
-            select(di == 6).spec.values.r.image = strenv(IMAGE_TAG) + "-r" |
-            select(di == 6).spec.values.r.image line_comment = strenv(R_IMAGE_POLICY_TAG) |
+            select(di == 6).spec.values.r.image.registry = strenv(REGISTRY) |
+            select(di == 6).spec.values.r.image.repository = strenv(GITHUB_REPOSITORY) |
+            select(di == 6).spec.values.r.image,tag = strenv(IMAGE_TAG) + "-r" |
+            select(di == 6).spec.values.r.image.tag line_comment = strenv(R_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.r.memoryRequest = strenv(MEMORY_REQUEST) |
-            select(di == 6).spec.values.python.image = strenv(IMAGE_TAG) + "-python" |
+            select(di == 6).spec.values.python.image.registry = strenv(REGISTRY) |
+            select(di == 6).spec.values.python.image.repository = strenv(GITHUB_REPOSITORY) |
+            select(di == 6).spec.values.python.image.tag = strenv(IMAGE_TAG) + "-python" |
             select(di == 6).spec.values.python.image line_comment = strenv(PYTHON_IMAGE_POLICY_TAG) |
             select(di == 6).spec.values.datadogTags = "kube_namespace:" + strenv(NAMESPACE)
           ' .flux.yaml > $DEPLOYMENT_NAME.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -376,13 +376,13 @@ jobs:
             select(di == 3).metadata.name = strenv(DEPLOYMENT_NAME) + "-r" |
             select(di == 3).metadata.namespace = strenv(NAMESPACE) |
             select(di == 3).spec.imageRepositoryRef.name = strenv(DEPLOYMENT_NAME) |
-            select(di == 3).spec.filterTags.pattern = strenv(IMAGE_PATTERN) + "-r" |
+            select(di == 3).spec.filterTags.pattern = strenv(IMAGE_PATTERN) + "-r$" |
             select(di == 3).spec.filterTags.extract = strenv(IMAGE_EXTRACT) |
             select(di == 3).spec.policy.[strenv(IMAGE_POLICY_TYPE)].[strenv(IMAGE_POLICY_KEY)] = strenv(IMAGE_POLICY_VALUE) |
             select(di == 4).metadata.name = strenv(DEPLOYMENT_NAME) + "-python" |
             select(di == 4).metadata.namespace = strenv(NAMESPACE) |
             select(di == 4).spec.imageRepositoryRef.name = strenv(DEPLOYMENT_NAME) |
-            select(di == 4).spec.filterTags.pattern = strenv(IMAGE_PATTERN) + "-python" |
+            select(di == 4).spec.filterTags.pattern = strenv(IMAGE_PATTERN) + "-python$" |
             select(di == 4).spec.filterTags.extract = strenv(IMAGE_EXTRACT) |
             select(di == 4).spec.policy.[strenv(IMAGE_POLICY_TYPE)].[strenv(IMAGE_POLICY_KEY)] = strenv(IMAGE_POLICY_VALUE) |
             select(di == 5).metadata.name = strenv(DEPLOYMENT_NAME) + "-image-update" |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,12 +363,13 @@ jobs:
 
           export NAMESPACE="$DEPLOYMENT_NAME-$SANDBOX_ID"
           export R_IMAGE_POLICY_TAG="{\"\$imagepolicy\": \"$NAMESPACE:$DEPLOYMENT_NAME-r:tag\"}"
+          export CHART_CRD_NAME="$DEPLOYENT_NAME-chart"
           export PYTHON_IMAGE_POLICY_TAG="{\"\$imagepolicy\": \"$NAMESPACE:$DEPLOYMENT_NAME-python:tag\"}"
 
           yq '
             select(di == 0).metadata.name = strenv(NAMESPACE) |
             select(di == 0).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
-            select(di == 1).metadata.name = strenv(DEPLOYMENT_NAME) |
+            select(di == 1).metadata.name = strenv(CHART_CRD_NAME) |
             select(di == 1).metadata.namespace = strenv(NAMESPACE) |
             select(di == 1).spec.ref.branch = strenv(CHART_REF) |
             select(di == 2).metadata.name = strenv(DEPLOYMENT_NAME) |
@@ -392,7 +393,7 @@ jobs:
             select(di == 6).metadata.namespace = strenv(NAMESPACE) |
             select(di == 6).metadata.labels.sandboxId = strenv(SANDBOX_ID) |
             select(di == 6).spec.releaseName = strenv(DEPLOYMENT_NAME) |
-            select(di == 6).spec.chart.spec.sourceRef.name = strenv(DEPLOYMENT_NAME) |
+            select(di == 6).spec.chart.spec.sourceRef.name = strenv(CHART_CRD_NAME) |
             select(di == 6).spec.chart.spec.sourceRef.namespace = strenv(NAMESPACE) |
             select(di == 6).spec.values.kubernetes.env = strenv(KUBERNETES_ENV) |
             select(di == 6).spec.values.serviceAccount.iamRole = "worker-role-" + strenv(KUBERNETES_ENV) |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -448,7 +448,7 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
           source_file: ${{ needs.build-docker.outputs.ref-id }}.yaml
-          destination_repo: '${{ github.repository_owner }}/flux-v2-migration'
+          destination_repo: '${{ github.repository_owner }}/releases'
           destination_folder: 'staging-candidates/${{ steps.fill-metadata.outputs.deployment-name }}'
           user_email: 'ci@biomage.net'
           user_name: 'Biomage CI/CD'

--- a/chart-infra/templates/pod-template.tpl
+++ b/chart-infra/templates/pod-template.tpl
@@ -7,7 +7,7 @@
     spec:
       containers:
       - name: "{{ .Release.Name }}-r"
-        image: "{{ .Values.r.image }}"
+        image: "{{ .Values.r.image.registry }}/{{ .Values.r.image.repository }}:{{ .Values.r.image.tag }}"
         volumeMounts:
         - name: 'data'
           mountPath: '/data'
@@ -24,7 +24,7 @@
           requests:
             memory: "{{ .Values.r.memoryRequest }}"
       - name: "{{ .Release.Name }}"
-        image: "{{ .Values.python.image }}"
+        image: "{{ .Values.python.image.registry }}/{{ .Values.python.image.repository }}:{{ .Values.python.image.tag }}"
         env:
         - name: AWS_ACCOUNT_ID
           value: "{{ .Values.myAccount.accountId }}"

--- a/r/work.R
+++ b/r/work.R
@@ -4,7 +4,7 @@ library(dplyr)
 for (f in list.files("R", ".R$", full.names = TRUE)) source(f)
 load('R/sysdata.rda') # constants
 
-# TEST IMAGE CHANGE
+# TEST FLUX IMAGE UPDATE - REMOVE TAG BEFORE MERGING
 
 load_data <- function(fpath) {
   loaded <- FALSE

--- a/r/work.R
+++ b/r/work.R
@@ -4,6 +4,7 @@ library(dplyr)
 for (f in list.files("R", ".R$", full.names = TRUE)) source(f)
 load('R/sysdata.rda') # constants
 
+
 load_data <- function(fpath) {
   loaded <- FALSE
   data <- NULL
@@ -18,7 +19,7 @@ load_data <- function(fpath) {
         f <- readRDS(fpath)
         loaded <- TRUE
         length <- dim(f)
-
+        
         message(
           "Data successfully loaded, dimensions",
           length[1], "x", length[2]

--- a/r/work.R
+++ b/r/work.R
@@ -4,8 +4,6 @@ library(dplyr)
 for (f in list.files("R", ".R$", full.names = TRUE)) source(f)
 load('R/sysdata.rda') # constants
 
-# TEST FLUX IMAGE UPDATE - REMOVE TAG BEFORE MERGING
-
 load_data <- function(fpath) {
   loaded <- FALSE
   data <- NULL

--- a/r/work.R
+++ b/r/work.R
@@ -4,6 +4,7 @@ library(dplyr)
 for (f in list.files("R", ".R$", full.names = TRUE)) source(f)
 load('R/sysdata.rda') # constants
 
+# TEST IMAGE CHANGE
 
 load_data <- function(fpath) {
   loaded <- FALSE
@@ -19,7 +20,7 @@ load_data <- function(fpath) {
         f <- readRDS(fpath)
         loaded <- TRUE
         length <- dim(f)
-        
+
         message(
           "Data successfully loaded, dimensions",
           length[1], "x", length[2]


### PR DESCRIPTION
# Description
We have to update the Helm charts because Flux v2 removes the use of HelmOperator and uses HelmController instead.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-2211

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.