### PR TITLE
change default prod timeout to 30 mins

### DIFF
--- a/python/src/worker/config/__init__.py
+++ b/python/src/worker/config/__init__.py
@@ -13,7 +13,7 @@ cluster_env = os.getenv("CLUSTER_ENV")
 timeout = int(
     os.getenv(
         "WORK_TIMEOUT",
-        default=str(60 * 60 * 3) if kube_env == "production" else str(60 * 10),
+        default=str(60 * 30) if kube_env == "production" else str(60 * 10),
     )
 )
 


### PR DESCRIPTION
# Description
Change default worker timeout to 30 mins

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
